### PR TITLE
Version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everypay/googlepay-rn-bridge",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "EveryPay Google Pay React Native Bridge (Android Only)",
   "homepage": "https://github.com/UnifiedPaymentSolutions/googlepay-rn-bridge",
   "publishConfig": {


### PR DESCRIPTION
This pull request updates the package version of `@everypay/googlepay-rn-bridge` from `1.0.1` to `2.0.0` in `package.json`, indicating a major release.